### PR TITLE
Add a bit of cross-platform compatibility

### DIFF
--- a/tasks/install-from-package.yml
+++ b/tasks/install-from-package.yml
@@ -1,7 +1,14 @@
 ---
+
+- name: Check if apt exists
+  shell: apt --version
+  register: apt_shell
+  failed_when: false
+
 - name: Update apt cache.
   apt:
     update_cache: yes
+  when: apt_shell.rc == 0
   changed_when: false
 
 - name: Install amazon-ecr-credential-helper from package

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,11 @@
   when: (ansible_facts['distribution'] == 'Debian' and ansible_facts['distribution_major_version'] is version('9', '<=')) or
         (ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version'] is version('18.04', '<='))
 
+- name: Set package name
+  set_fact:
+    aws_ecr_cred_helper_pkg: docker-credential-helper-ecr
+  when: ansible_facts['distribution'] == 'MacOSX'
+
 - name: Include install from package tasks
   include_tasks: install-from-package.yml
   when: not install_from_binary


### PR DESCRIPTION
This checks for the existence of apt before we attempt to make a call to it.
We also gate the package name to install based on OS (use the brew name)