### PR TITLE
Configure Docker config.json for multiple users

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Role default variables from `defaults/main.yml`.
 ```yaml
 aws_ecr_cred_helper_bin_version: 0.5.0
 aws_ecr_cred_helper_pkg: "amazon-ecr-credential-helper"
+aws_ecr_cred_helper_docker_config_dirs:
+  - "{{ ansible_user_dir }}"
 install_from_binary: false
 
 # cred_helper_config: {}

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Role default variables from `defaults/main.yml`.
 ```yaml
 aws_ecr_cred_helper_bin_version: 0.5.0
 aws_ecr_cred_helper_pkg: "amazon-ecr-credential-helper"
-aws_ecr_cred_helper_docker_config_dirs:
-  - "{{ ansible_user_dir }}"
+aws_ecr_cred_helper_users:
+  - "{{ ansible_env.USER }}"
 install_from_binary: false
 
 # cred_helper_config: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 aws_ecr_cred_helper_bin_version: 0.5.0
 aws_ecr_cred_helper_pkg: "amazon-ecr-credential-helper"
-aws_ecr_cred_helper_docker_config_dirs:
-  - "{{ ansible_user_dir }}"
+aws_ecr_cred_helper_users:
+  - "{{ ansible_env.USER }}"
 install_from_binary: false
 
 # cred_helper_config: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 aws_ecr_cred_helper_bin_version: 0.5.0
 aws_ecr_cred_helper_pkg: "amazon-ecr-credential-helper"
+aws_ecr_cred_helper_docker_config_dirs:
+  - "{{ ansible_user_dir }}"
 install_from_binary: false
 
 # cred_helper_config: {}

--- a/tasks/configure-docker-json.yml
+++ b/tasks/configure-docker-json.yml
@@ -1,19 +1,29 @@
 ---
+- name: "Configuring config.json for:"
+  debug:
+    var: item
+
+- name: Get user data
+  user:
+    name: "{{ item }}"
+  register: user_data
+
 - name: Creates docker config directory
   file:
-    path: "{{ item }}/.docker/"
+    path: "{{ user_data.home }}/.docker/"
     state: directory
-    owner: "{{ ansible_user_id }}"
+    owner: "{{ user_data.name }}"
+    group: "{{ user_data.name }}"
     mode: '0655'
 
 - name: Check if docker config exists
   stat:
-    path: '{{ item }}/.docker/config.json'
+    path: '{{ user_data.home }}/.docker/config.json'
   register: stat_result
 
 - name: Read docker config file
   slurp:
-    src: '{{ item }}/.docker/config.json'
+    src: '{{ user_data.home }}/.docker/config.json'
   register: config_file
   when: stat_result.stat.exists
 
@@ -28,5 +38,7 @@
 - name: Write merged content to config file
   copy:
     content: "{{ result_var | to_nice_json }}"
-    dest: '{{ item }}/.docker/config.json'
+    dest: '{{ user_data.home }}/.docker/config.json'
+    owner: "{{ user_data.name }}"
+    group: "{{ user_data.name }}"
     mode: '0600'

--- a/tasks/configure-docker-json.yml
+++ b/tasks/configure-docker-json.yml
@@ -1,19 +1,19 @@
 ---
 - name: Creates docker config directory
   file:
-    path: "{{ ansible_user_dir }}/.docker/"
+    path: "{{ item }}/.docker/"
     state: directory
     owner: "{{ ansible_user_id }}"
     mode: '0655'
 
 - name: Check if docker config exists
   stat:
-    path: '{{ ansible_user_dir }}/.docker/config.json'
+    path: '{{ item }}/.docker/config.json'
   register: stat_result
 
 - name: Read docker config file
   slurp:
-    src: '{{ ansible_user_dir }}/.docker/config.json'
+    src: '{{ item }}/.docker/config.json'
   register: config_file
   when: stat_result.stat.exists
 
@@ -28,5 +28,5 @@
 - name: Write merged content to config file
   copy:
     content: "{{ result_var | to_nice_json }}"
-    dest: '{{ ansible_user_dir }}/.docker/config.json'
+    dest: '{{ item }}/.docker/config.json'
     mode: '0600'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,3 +16,4 @@
 - name: Include docker config tasks
   include_tasks: configure-docker-json.yml
   when: cred_helper_config is defined and cred_helper_config.keys() | length > 0
+  with_items: "{{ aws_ecr_cred_helper_docker_config_dirs }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,4 +16,4 @@
 - name: Include docker config tasks
   include_tasks: configure-docker-json.yml
   when: cred_helper_config is defined and cred_helper_config.keys() | length > 0
-  with_items: "{{ aws_ecr_cred_helper_docker_config_dirs }}"
+  with_items: "{{ aws_ecr_cred_helper_users }}"


### PR DESCRIPTION
These changes:

- Allow you to define a list of users who will have their config.json updated
- Set decent chown permissions on any created dirs/files 
- Keep existing behaviour the same
  -`ansible_env.USER` is set in the defaults (which is the Ansible user), so `user_data.home` == `ansible_user_dir`

This is the most portable/readable way I could do it.

The alternative would be to have `with_items: "{{ aws_ecr_cred_helper_users }}"` on every task in `tasks/configure-docker-json.yml`.

Let me know your thoughts.


Tested on Ubuntu 22.04.