### PR TITLE
fix: ansible-lint errors

### DIFF
--- a/tasks/configure-docker-json.yml
+++ b/tasks/configure-docker-json.yml
@@ -1,15 +1,15 @@
 ---
 - name: "Configuring config.json for:"
-  debug:
+  ansible.builtin.debug:
     var: item
 
 - name: Get user data
-  user:
+  ansible.builtin.user:
     name: "{{ item }}"
   register: user_data
 
 - name: Creates docker config directory
-  file:
+  ansible.builtin.file:
     path: "{{ user_data.home }}/.docker/"
     state: directory
     owner: "{{ user_data.name }}"
@@ -17,26 +17,26 @@
     mode: '0655'
 
 - name: Check if docker config exists
-  stat:
+  ansible.builtin.stat:
     path: '{{ user_data.home }}/.docker/config.json'
   register: stat_result
 
 - name: Read docker config file
-  slurp:
+  ansible.builtin.slurp:
     src: '{{ user_data.home }}/.docker/config.json'
   register: config_file
   when: stat_result.stat.exists
 
 - name: Set fact original_content
-  set_fact:
+  ansible.builtin.set_fact:
     original_content: "{{ config_file.content | b64decode | from_json if config_file.content is defined else {} }}"
 
 - name: Add cred_helper_config to docker config json object
-  set_fact:
+  ansible.builtin.set_fact:
     result_var: "{{ original_content | combine(cred_helper_config | to_json | from_json) }}"
 
 - name: Write merged content to config file
-  copy:
+  ansible.builtin.copy:
     content: "{{ result_var | to_nice_json }}"
     dest: '{{ user_data.home }}/.docker/config.json'
     owner: "{{ user_data.name }}"

--- a/tasks/install-from-binary.yml
+++ b/tasks/install-from-binary.yml
@@ -1,12 +1,12 @@
 ---
 - name: Uninstall amazon-ecr-credential-helper from package
-  package:
+  ansible.builtin.package:
     name: "{{ aws_ecr_cred_helper_pkg }}"
     state: absent
 
 # https://github.com/awslabs/amazon-ecr-credential-helper/releases
 - name: Install amazon-ecr-credential-helper from binary
-  get_url:
+  ansible.builtin.get_url:
     url: https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/{{
       aws_ecr_cred_helper_bin_version }}/linux-amd64/docker-credential-ecr-login
     dest: /usr/local/bin/docker-credential-ecr-login

--- a/tasks/install-from-package.yml
+++ b/tasks/install-from-package.yml
@@ -1,10 +1,10 @@
 ---
 - name: Update apt cache.
-  apt:
+  ansible.builtin.apt:
     update_cache: yes
   changed_when: false
 
 - name: Install amazon-ecr-credential-helper from package
-  package:
+  ansible.builtin.package:
     name: "{{ aws_ecr_cred_helper_pkg }}"
     state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,19 @@
 ---
 - name: Set installation method
-  set_fact:
+  ansible.builtin.set_fact:
     install_from_binary: true
   when: (ansible_facts['distribution'] == 'Debian' and ansible_facts['distribution_major_version'] is version('9', '<=')) or
         (ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version'] is version('18.04', '<='))
 
 - name: Include install from package tasks
-  include_tasks: install-from-package.yml
+  ansible.builtin.include_tasks: install-from-package.yml
   when: not install_from_binary
 
 - name: Include install from binary tasks
-  include_tasks: install-from-binary.yml
+  ansible.builtin.include_tasks: install-from-binary.yml
   when: install_from_binary
 
 - name: Include docker config tasks
-  include_tasks: configure-docker-json.yml
+  ansible.builtin.include_tasks: configure-docker-json.yml
   when: cred_helper_config is defined and cred_helper_config.keys() | length > 0
   with_items: "{{ aws_ecr_cred_helper_users }}"


### PR DESCRIPTION
Fixes the ansible-lint errors, pretty much just using full names for the builtins.

There are a couple of warnings for the Galaxy meta.yml, but they don't cause it to fail.